### PR TITLE
Markdown UI test

### DIFF
--- a/Conscriptor.xcodeproj/project.pbxproj
+++ b/Conscriptor.xcodeproj/project.pbxproj
@@ -15,12 +15,12 @@
 		68871BAC26B0B3750001421E /* MarkdownEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68871BAB26B0B3750001421E /* MarkdownEditorView.swift */; };
 		68871BAE26B0B3770001421E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 68871BAD26B0B3770001421E /* Assets.xcassets */; };
 		68871BB126B0B3770001421E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 68871BB026B0B3770001421E /* Preview Assets.xcassets */; };
-		D5193772273CDA8100DDB43C /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = D5193771273CDA8100DDB43C /* MarkdownUI */; };
 		D51B6297270F692800DAC0C6 /* MarkdownEditorToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51B6296270F692800DAC0C6 /* MarkdownEditorToolbar.swift */; };
 		D53C190A26E0CF3100E7934B /* HighlightedTextEditor in Frameworks */ = {isa = PBXBuildFile; productRef = D53C190926E0CF3100E7934B /* HighlightedTextEditor */; };
 		D56601FD26EB3F3D0071C6E3 /* StringSubscriptExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56601FC26EB3F3D0071C6E3 /* StringSubscriptExtension.swift */; };
 		D576840926E0A18700E2A12B /* github-light.css in Resources */ = {isa = PBXBuildFile; fileRef = D576840826E0A18700E2A12B /* github-light.css */; };
 		D576840D26E0ACCF00E2A12B /* IntrospectExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D576840C26E0ACCF00E2A12B /* IntrospectExtension.swift */; };
+		D585951E273FAA3C0017586F /* Ink in Frameworks */ = {isa = PBXBuildFile; productRef = D585951D273FAA3C0017586F /* Ink */; };
 		D5989BA626F45E5D00D9E496 /* NotificationName+MarkdownEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5989BA526F45E5D00D9E496 /* NotificationName+MarkdownEditorView.swift */; };
 		D5B3E0482705206600A912E2 /* github-dark.css in Resources */ = {isa = PBXBuildFile; fileRef = D5B3E0472705206600A912E2 /* github-dark.css */; };
 		D5CE033226F3F9B000CB86E5 /* MarkdownFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CE033126F3F9B000CB86E5 /* MarkdownFormatter.swift */; };
@@ -55,9 +55,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D585951E273FAA3C0017586F /* Ink in Frameworks */,
 				D53C190A26E0CF3100E7934B /* HighlightedTextEditor in Frameworks */,
 				683D922A26B107EB00E5EF82 /* Introspect in Frameworks */,
-				D5193772273CDA8100DDB43C /* MarkdownUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -180,7 +180,7 @@
 			packageProductDependencies = (
 				683D922926B107EB00E5EF82 /* Introspect */,
 				D53C190926E0CF3100E7934B /* HighlightedTextEditor */,
-				D5193771273CDA8100DDB43C /* MarkdownUI */,
+				D585951D273FAA3C0017586F /* Ink */,
 			);
 			productName = Conscriptor;
 			productReference = 68871BA426B0B3750001421E /* Conscriptor.app */;
@@ -212,7 +212,7 @@
 			packageReferences = (
 				683D922826B107EB00E5EF82 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
 				D53C190826E0CF3100E7934B /* XCRemoteSwiftPackageReference "HighlightedTextEditor" */,
-				D5193770273CDA8100DDB43C /* XCRemoteSwiftPackageReference "MarkdownUI" */,
+				D585951C273FAA3C0017586F /* XCRemoteSwiftPackageReference "Ink" */,
 			);
 			productRefGroup = 68871BA526B0B3750001421E /* Products */;
 			projectDirPath = "";
@@ -459,20 +459,20 @@
 				minimumVersion = 0.1.3;
 			};
 		};
-		D5193770273CDA8100DDB43C /* XCRemoteSwiftPackageReference "MarkdownUI" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/gonzalezreal/MarkdownUI";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.5.2;
-			};
-		};
 		D53C190826E0CF3100E7934B /* XCRemoteSwiftPackageReference "HighlightedTextEditor" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kyle-n/HighlightedTextEditor";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 2.0.0;
+			};
+		};
+		D585951C273FAA3C0017586F /* XCRemoteSwiftPackageReference "Ink" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/JohnSundell/Ink";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.5.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -483,15 +483,15 @@
 			package = 683D922826B107EB00E5EF82 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
 			productName = Introspect;
 		};
-		D5193771273CDA8100DDB43C /* MarkdownUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = D5193770273CDA8100DDB43C /* XCRemoteSwiftPackageReference "MarkdownUI" */;
-			productName = MarkdownUI;
-		};
 		D53C190926E0CF3100E7934B /* HighlightedTextEditor */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D53C190826E0CF3100E7934B /* XCRemoteSwiftPackageReference "HighlightedTextEditor" */;
 			productName = HighlightedTextEditor;
+		};
+		D585951D273FAA3C0017586F /* Ink */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D585951C273FAA3C0017586F /* XCRemoteSwiftPackageReference "Ink" */;
+			productName = Ink;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Conscriptor.xcodeproj/project.pbxproj
+++ b/Conscriptor.xcodeproj/project.pbxproj
@@ -15,8 +15,8 @@
 		68871BAC26B0B3750001421E /* MarkdownEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68871BAB26B0B3750001421E /* MarkdownEditorView.swift */; };
 		68871BAE26B0B3770001421E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 68871BAD26B0B3770001421E /* Assets.xcassets */; };
 		68871BB126B0B3770001421E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 68871BB026B0B3770001421E /* Preview Assets.xcassets */; };
+		D5193772273CDA8100DDB43C /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = D5193771273CDA8100DDB43C /* MarkdownUI */; };
 		D51B6297270F692800DAC0C6 /* MarkdownEditorToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51B6296270F692800DAC0C6 /* MarkdownEditorToolbar.swift */; };
-		D53C190426E0CCEB00E7934B /* MarkdownSyntax in Frameworks */ = {isa = PBXBuildFile; productRef = D53C190326E0CCEB00E7934B /* MarkdownSyntax */; };
 		D53C190A26E0CF3100E7934B /* HighlightedTextEditor in Frameworks */ = {isa = PBXBuildFile; productRef = D53C190926E0CF3100E7934B /* HighlightedTextEditor */; };
 		D56601FD26EB3F3D0071C6E3 /* StringSubscriptExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56601FC26EB3F3D0071C6E3 /* StringSubscriptExtension.swift */; };
 		D576840926E0A18700E2A12B /* github-light.css in Resources */ = {isa = PBXBuildFile; fileRef = D576840826E0A18700E2A12B /* github-light.css */; };
@@ -55,9 +55,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D53C190426E0CCEB00E7934B /* MarkdownSyntax in Frameworks */,
 				D53C190A26E0CF3100E7934B /* HighlightedTextEditor in Frameworks */,
 				683D922A26B107EB00E5EF82 /* Introspect in Frameworks */,
+				D5193772273CDA8100DDB43C /* MarkdownUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -179,8 +179,8 @@
 			name = Conscriptor;
 			packageProductDependencies = (
 				683D922926B107EB00E5EF82 /* Introspect */,
-				D53C190326E0CCEB00E7934B /* MarkdownSyntax */,
 				D53C190926E0CF3100E7934B /* HighlightedTextEditor */,
+				D5193771273CDA8100DDB43C /* MarkdownUI */,
 			);
 			productName = Conscriptor;
 			productReference = 68871BA426B0B3750001421E /* Conscriptor.app */;
@@ -211,8 +211,8 @@
 			mainGroup = 68871B9B26B0B3750001421E;
 			packageReferences = (
 				683D922826B107EB00E5EF82 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */,
-				D53C190226E0CCEB00E7934B /* XCRemoteSwiftPackageReference "MarkdownSyntax" */,
 				D53C190826E0CF3100E7934B /* XCRemoteSwiftPackageReference "HighlightedTextEditor" */,
+				D5193770273CDA8100DDB43C /* XCRemoteSwiftPackageReference "MarkdownUI" */,
 			);
 			productRefGroup = 68871BA526B0B3750001421E /* Products */;
 			projectDirPath = "";
@@ -459,12 +459,12 @@
 				minimumVersion = 0.1.3;
 			};
 		};
-		D53C190226E0CCEB00E7934B /* XCRemoteSwiftPackageReference "MarkdownSyntax" */ = {
+		D5193770273CDA8100DDB43C /* XCRemoteSwiftPackageReference "MarkdownUI" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/hebertialmeida/MarkdownSyntax";
+			repositoryURL = "https://github.com/gonzalezreal/MarkdownUI";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 0.5.2;
 			};
 		};
 		D53C190826E0CF3100E7934B /* XCRemoteSwiftPackageReference "HighlightedTextEditor" */ = {
@@ -483,10 +483,10 @@
 			package = 683D922826B107EB00E5EF82 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
 			productName = Introspect;
 		};
-		D53C190326E0CCEB00E7934B /* MarkdownSyntax */ = {
+		D5193771273CDA8100DDB43C /* MarkdownUI */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = D53C190226E0CCEB00E7934B /* XCRemoteSwiftPackageReference "MarkdownSyntax" */;
-			productName = MarkdownSyntax;
+			package = D5193770273CDA8100DDB43C /* XCRemoteSwiftPackageReference "MarkdownUI" */;
+			productName = MarkdownUI;
 		};
 		D53C190926E0CF3100E7934B /* HighlightedTextEditor */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Conscriptor.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Conscriptor.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,24 @@
   "object": {
     "pins": [
       {
+        "package": "AttributedText",
+        "repositoryURL": "https://github.com/gonzalezreal/AttributedText",
+        "state": {
+          "branch": null,
+          "revision": "c345033e22d5a1cd0e9fe0ec405cc809a8349586",
+          "version": "0.3.1"
+        }
+      },
+      {
+        "package": "combine-schedulers",
+        "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
+        "state": {
+          "branch": null,
+          "revision": "4cf088c29a20f52be0f2ca54992b492c54e0076b",
+          "version": "0.5.3"
+        }
+      },
+      {
         "package": "HighlightedTextEditor",
         "repositoryURL": "https://github.com/kyle-n/HighlightedTextEditor",
         "state": {
@@ -11,21 +29,39 @@
         }
       },
       {
-        "package": "MarkdownSyntax",
-        "repositoryURL": "https://github.com/hebertialmeida/MarkdownSyntax",
+        "package": "MarkdownUI",
+        "repositoryURL": "https://github.com/gonzalezreal/MarkdownUI",
         "state": {
           "branch": null,
-          "revision": "17d7557d08adb3c184a45a3dbd4d3144db5dfda5",
-          "version": "1.1.0"
+          "revision": "29d94710545952dd4c724cc2ca901848eef54ded",
+          "version": "0.5.2"
         }
       },
       {
-        "package": "cmark_gfm",
-        "repositoryURL": "https://github.com/hebertialmeida/swift-cmark-gfm",
+        "package": "NetworkImage",
+        "repositoryURL": "https://github.com/gonzalezreal/NetworkImage",
         "state": {
           "branch": null,
-          "revision": "d0a8b625a499389c12fa08375e6d81d0c6f66cb4",
-          "version": "1.1.1"
+          "revision": "04167e81ed89a14b5da9b856ead306b969bb5abd",
+          "version": "3.1.2"
+        }
+      },
+      {
+        "package": "cmark",
+        "repositoryURL": "https://github.com/SwiftDocOrg/swift-cmark.git",
+        "state": {
+          "branch": null,
+          "revision": "9c8096a23f44794bde297452d87c455fc4f76d42",
+          "version": "0.29.0+20210102.9c8096a"
+        }
+      },
+      {
+        "package": "SwiftCommonMark",
+        "repositoryURL": "https://github.com/gonzalezreal/SwiftCommonMark",
+        "state": {
+          "branch": null,
+          "revision": "ed60da54305c244d0f77bc8d08495e04161e96a4",
+          "version": "0.1.2"
         }
       },
       {
@@ -35,6 +71,15 @@
           "branch": null,
           "revision": "2e09be8af614401bc9f87d40093ec19ce56ccaf2",
           "version": "0.1.3"
+        }
+      },
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "50a70a9d3583fe228ce672e8923010c8df2deddd",
+          "version": "0.2.1"
         }
       }
     ]

--- a/Conscriptor.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Conscriptor.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,24 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "AttributedText",
-        "repositoryURL": "https://github.com/gonzalezreal/AttributedText",
-        "state": {
-          "branch": null,
-          "revision": "c345033e22d5a1cd0e9fe0ec405cc809a8349586",
-          "version": "0.3.1"
-        }
-      },
-      {
-        "package": "combine-schedulers",
-        "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
-        "state": {
-          "branch": null,
-          "revision": "4cf088c29a20f52be0f2ca54992b492c54e0076b",
-          "version": "0.5.3"
-        }
-      },
-      {
         "package": "HighlightedTextEditor",
         "repositoryURL": "https://github.com/kyle-n/HighlightedTextEditor",
         "state": {
@@ -29,39 +11,12 @@
         }
       },
       {
-        "package": "MarkdownUI",
-        "repositoryURL": "https://github.com/gonzalezreal/MarkdownUI",
+        "package": "Ink",
+        "repositoryURL": "https://github.com/JohnSundell/Ink",
         "state": {
           "branch": null,
-          "revision": "29d94710545952dd4c724cc2ca901848eef54ded",
-          "version": "0.5.2"
-        }
-      },
-      {
-        "package": "NetworkImage",
-        "repositoryURL": "https://github.com/gonzalezreal/NetworkImage",
-        "state": {
-          "branch": null,
-          "revision": "04167e81ed89a14b5da9b856ead306b969bb5abd",
-          "version": "3.1.2"
-        }
-      },
-      {
-        "package": "cmark",
-        "repositoryURL": "https://github.com/SwiftDocOrg/swift-cmark.git",
-        "state": {
-          "branch": null,
-          "revision": "9c8096a23f44794bde297452d87c455fc4f76d42",
-          "version": "0.29.0+20210102.9c8096a"
-        }
-      },
-      {
-        "package": "SwiftCommonMark",
-        "repositoryURL": "https://github.com/gonzalezreal/SwiftCommonMark",
-        "state": {
-          "branch": null,
-          "revision": "ed60da54305c244d0f77bc8d08495e04161e96a4",
-          "version": "0.1.2"
+          "revision": "77c3d8953374a9cf5418ef0bd7108524999de85a",
+          "version": "0.5.1"
         }
       },
       {
@@ -71,15 +26,6 @@
           "branch": null,
           "revision": "2e09be8af614401bc9f87d40093ec19ce56ccaf2",
           "version": "0.1.3"
-        }
-      },
-      {
-        "package": "xctest-dynamic-overlay",
-        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
-        "state": {
-          "branch": null,
-          "revision": "50a70a9d3583fe228ce672e8923010c8df2deddd",
-          "version": "0.2.1"
         }
       }
     ]

--- a/Conscriptor/ConscriptorApp.swift
+++ b/Conscriptor/ConscriptorApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct ConscriptorApp: App {
     var body: some Scene {
         DocumentGroup(newDocument: ConscriptorDocument()) { file in
-            MarkdownEditorView(document: file.$document)
+            MarkdownEditorView(conscriptorDocument: file.$document)
                 .frame(minWidth: 400, minHeight: 500)
         }
         .commands {

--- a/Conscriptor/ConscriptorApp.swift
+++ b/Conscriptor/ConscriptorApp.swift
@@ -23,25 +23,52 @@ struct ConscriptorApp: App {
                     nc.post(name: .formatBold, object: nil)
                 } label: {
                     Text("Bold")
-                }.keyboardShortcut("b", modifiers: .command)
+                }
+                .keyboardShortcut("b", modifiers: .command)
+
                 Button {
                     let nc = NotificationCenter.default
                     nc.post(name: .formatItalic, object: nil)
                 } label: {
                     Text("Italic")
-                }.keyboardShortcut("i", modifiers: .command)
+                }
+                .keyboardShortcut("i", modifiers: .command)
+
                 Button {
                     let nc = NotificationCenter.default
                     nc.post(name: .formatStrikethrough, object: nil)
                 } label: {
                     Text("Strikethrough")
-                }.keyboardShortcut("k", modifiers: .command)
+                }
+                .keyboardShortcut("k", modifiers: .command)
+
                 Button {
                     let nc = NotificationCenter.default
                     nc.post(name: .formatInlineCode, object: nil)
                 } label: {
                     Text("Inline Code")
-                }.keyboardShortcut("/", modifiers: .command)
+                }
+                .keyboardShortcut("/", modifiers: .command)
+                
+                Divider()
+                
+                Button {
+//                    let nc = NotificationCenter.default
+//                    nc.post(name: .insertImage, object: nil)
+                } label: {
+                    Text("Insert Image")
+                }
+                .keyboardShortcut("i", modifiers: .option)
+                .disabled(true)
+                
+                Button {
+//                    let nc = NotificationCenter.default
+//                    nc.post(name: .insertLink, object: nil)
+                } label: {
+                    Text("Add Link")
+                }
+                .keyboardShortcut("l", modifiers: .command)
+                .disabled(true)
             }
         }
     }

--- a/Conscriptor/Resources/github-dark.css
+++ b/Conscriptor/Resources/github-dark.css
@@ -27,7 +27,8 @@ body {
   line-height: 1.6;
   padding-top: 10px;
   padding-bottom: 10px;
-  background-color: #0e1116;
+  background-color: rgba(14, 17, 22, 0.01); /* workaround for getting scrollers to be correct color with transparent background*/
+/*  background-color: transparent;*/
   padding: 30px;
   color: #cad1d8;
 }
@@ -104,11 +105,13 @@ h6 tt, h6 code {
 
 h1 {
   font-size: 28px;
+  color: #cad1d9;
 }
 
 h2 {
   font-size: 24px;
   border-bottom: 1px solid #cccccc;
+  color: #cad1d9;
 }
 
 h3 {
@@ -369,7 +372,8 @@ code, tt {
   white-space: nowrap;
   border: 1px solid #21252a;
   background-color: #353940;
-  border-radius: 3px;
+  border-radius: 4px;
+  font-family: Menlo, monospace;
 }
 
 pre code {

--- a/Conscriptor/Resources/github-light.css
+++ b/Conscriptor/Resources/github-light.css
@@ -27,7 +27,8 @@ body {
   line-height: 1.6;
   padding-top: 10px;
   padding-bottom: 10px;
-  background-color: white;
+  background-color: rgba(255, 255, 255, 0.01); /* workaround for getting scrollers to be correct color with transparent background*/
+/*  background-color: transparent;*/
   padding: 30px;
   color: #333;
 }
@@ -372,7 +373,8 @@ code, tt {
   white-space: nowrap;
   border: 1px solid #eaeaea;
   background-color: #f8f8f8;
-  border-radius: 3px;
+  border-radius: 4px;
+  font-family: Menlo, monospace;
 }
 
 pre code {

--- a/Conscriptor/Views/MarkdownEditorToolbar.swift
+++ b/Conscriptor/Views/MarkdownEditorToolbar.swift
@@ -11,7 +11,7 @@ import AppKit
 
 struct MarkdownEditorToolbar: CustomizableToolbarContent {
     @Binding var document: ConscriptorDocument
-    @State var showingPreview: Bool
+    @Binding var showingPreview: Bool
     let textView: NSTextView?
     
     var body: some CustomizableToolbarContent {
@@ -75,12 +75,11 @@ struct MarkdownEditorToolbar: CustomizableToolbarContent {
         Group {
             ToolbarItem(id: "sidebar") {
                 Button {
-                    withAnimation {
-                        showingPreview.toggle()
-                    }
+                    showingPreview.toggle()
                 } label: {
                     Label("Toggle Preview", systemImage: "sidebar.right")
-                }.disabled(true)
+                        .foregroundColor(Color(NSColor.secondaryLabelColor))
+                }
             }
         }
     }

--- a/Conscriptor/Views/MarkdownEditorView.swift
+++ b/Conscriptor/Views/MarkdownEditorView.swift
@@ -5,47 +5,76 @@
 //  Created by David Barsamian on 7/27/21.
 //
 
+import Combine
 import HighlightedTextEditor
 import Introspect
-import MarkdownSyntax
+import MarkdownUI
 import SwiftUI
 
 struct MarkdownEditorView: View {
     @Environment(\.colorScheme) var colorScheme
 
-    @Binding var document: ConscriptorDocument
+    @Binding var conscriptorDocument: ConscriptorDocument
+    
     @State private var showingPreview = true
     @State private var showingErrorAlert = false
     @State private var textView: NSTextView?
     @State private var splitView: NSSplitView?
+    @State private var scrollPosition = NSPoint.zero
 
-    var html: String {
-        do {
-            return try Markdown(text: document.text).renderHtml()
-        } catch {
-            print(error.localizedDescription)
-            showingErrorAlert.toggle()
-            return ""
-        }
+//    var html: String {
+//        do {
+//            return try Markdown(text: document.text).renderHtml()
+//        } catch {
+//            print(error.localizedDescription)
+//            showingErrorAlert.toggle()
+//            return ""
+//        }
+//    }
+
+    var editorContent: some View {
+        HighlightedTextEditor(text: $conscriptorDocument.text, highlightRules: .markdown)
+            .frame(minWidth: 300)
+            .introspectTextView { textView in
+                self.textView = textView
+            }
+    }
+
+    var livePreview: some View {
+//        WebView(html: html, scrollPosition: scrollPosition)
+//            .frame(minWidth: 300)
+//            .background(Color.white)
+//            .id(colorScheme)
+        Markdown(Document(stringLiteral: conscriptorDocument.text))
+            .padding(.horizontal, 30)
+            .padding(.vertical, 40)
     }
 
     // MARK: Body
 
     var body: some View {
-        GeometryReader { geo in
-            if geo.size.width < 600 {
-                VSplitView {
-                    editorContent()
-                    if showingPreview {
-                        previewContent()
-                    }
-                }
-            } else {
-                HSplitView {
-                    editorContent()
-                    if showingPreview {
-                        previewContent()
-                    }
+//        GeometryReader { geo in
+//            if geo.size.width < 600 {
+//                VSplitView {
+//                    editorContent
+//                    if showingPreview {
+//                        livePreview
+//                    }
+//                }
+//            } else {
+//                HSplitView {
+//                    editorContent
+//                    if showingPreview {
+//                        livePreview
+//                    }
+//                }
+//            }
+//        }
+        HSplitView {
+            editorContent
+            if showingPreview {
+                ScrollView {
+                    livePreview
                 }
             }
         }
@@ -54,7 +83,7 @@ struct MarkdownEditorView: View {
             splitView.dividerStyle = .thin
         })
         .toolbar(id: "editorControls") {
-            MarkdownEditorToolbar(document: $document, showingPreview: showingPreview, textView: textView)
+            MarkdownEditorToolbar(document: $conscriptorDocument, showingPreview: showingPreview, textView: textView)
         }
         .alert(isPresented: $showingErrorAlert) {
             Alert(title: Text("Error"), message: Text("Couldn't generate a live preview for the text entered. Please try again."), dismissButton: .cancel())
@@ -79,47 +108,30 @@ struct MarkdownEditorView: View {
         }
     }
 
-    @ViewBuilder
-    func editorContent() -> some View {
-        HighlightedTextEditor(text: $document.text, highlightRules: .markdown)
-            .frame(minWidth: 300)
-            .layoutPriority(1)
-            .introspectTextView { textView in
-                self.textView = textView
-            }
-    }
-
-    @ViewBuilder
-    func previewContent() -> some View {
-        WebView(html: html)
-            .frame(minWidth: 300)
-            .layoutPriority(1)
-            .background(Color.white)
-            .id(colorScheme)
-    }
-
     // MARK: - View Config
 
     public func setupNotifications() {
         let nc = NotificationCenter.default
         nc.addObserver(forName: .formatBold, object: nil, queue: .main) { _ in
-            MarkdownEditorController.format(&document, with: .bold, in: textView)
+            MarkdownEditorController.format(&conscriptorDocument, with: .bold, in: textView)
         }
         nc.addObserver(forName: .formatItalic, object: nil, queue: .main) { _ in
-            MarkdownEditorController.format(&document, with: .italic, in: textView)
+            MarkdownEditorController.format(&conscriptorDocument, with: .italic, in: textView)
         }
         nc.addObserver(forName: .formatStrikethrough, object: nil, queue: .main) { _ in
-            MarkdownEditorController.format(&document, with: .strikethrough, in: textView)
+            MarkdownEditorController.format(&conscriptorDocument, with: .strikethrough, in: textView)
         }
         nc.addObserver(forName: .formatInlineCode, object: nil, queue: .main) { _ in
-            MarkdownEditorController.format(&document, with: .code, in: textView)
+            MarkdownEditorController.format(&conscriptorDocument, with: .code, in: textView)
         }
     }
 
     private func configureTextView(_ textView: NSTextView) {
-        textView.enclosingScrollView?.autohidesScrollers = true
         textView.textContainerInset = .init(width: 30, height: 40)
         textView.usesFontPanel = false
+        if let scrollView = textView.enclosingScrollView {
+            scrollView.autohidesScrollers = true
+        }
     }
 
     private func configureSplitView(_ splitView: NSSplitView) {
@@ -129,6 +141,6 @@ struct MarkdownEditorView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        MarkdownEditorView(document: .constant(ConscriptorDocument()))
+        MarkdownEditorView(conscriptorDocument: .constant(ConscriptorDocument()))
     }
 }

--- a/Conscriptor/Views/MarkdownEditorView.swift
+++ b/Conscriptor/Views/MarkdownEditorView.swift
@@ -15,37 +15,29 @@ struct MarkdownEditorView: View {
     @Environment(\.colorScheme) var colorScheme
 
     @Binding var conscriptorDocument: ConscriptorDocument
-    
+
     @State private var showingPreview = true
     @State private var showingErrorAlert = false
     @State private var textView: NSTextView?
     @State private var splitView: NSSplitView?
     @State private var scrollPosition = NSPoint.zero
 
-//    var html: String {
-//        do {
-//            return try Markdown(text: document.text).renderHtml()
-//        } catch {
-//            print(error.localizedDescription)
-//            showingErrorAlert.toggle()
-//            return ""
-//        }
-//    }
-
     var editorContent: some View {
         HighlightedTextEditor(text: $conscriptorDocument.text, highlightRules: .markdown)
             .frame(minWidth: 300)
             .introspectTextView { textView in
                 self.textView = textView
+                textView.textContainerInset = .init(width: 30, height: 40)
+                textView.usesFontPanel = false
+                if let scrollView = textView.enclosingScrollView {
+                    scrollView.autohidesScrollers = true
+                }
             }
     }
 
     var livePreview: some View {
-//        WebView(html: html, scrollPosition: scrollPosition)
-//            .frame(minWidth: 300)
-//            .background(Color.white)
-//            .id(colorScheme)
         Markdown(Document(stringLiteral: conscriptorDocument.text))
+            .frame(minWidth: 300)
             .padding(.horizontal, 30)
             .padding(.vertical, 40)
     }
@@ -53,58 +45,48 @@ struct MarkdownEditorView: View {
     // MARK: Body
 
     var body: some View {
-//        GeometryReader { geo in
-//            if geo.size.width < 600 {
-//                VSplitView {
-//                    editorContent
-//                    if showingPreview {
-//                        livePreview
-//                    }
-//                }
-//            } else {
-//                HSplitView {
-//                    editorContent
-//                    if showingPreview {
-//                        livePreview
-//                    }
-//                }
-//            }
-//        }
-        HSplitView {
-            editorContent
-            if showingPreview {
-                ScrollView {
-                    livePreview
+        if showingPreview {
+            GeometryReader { geo in
+                if geo.size.width > 800 {
+                    HStack(spacing: 0) {
+                        editorContent
+                        Color.black
+                            .frame(width: 2)
+                        ScrollView {
+                            livePreview
+                        }
+                    }
+                } else {
+                    VStack(spacing: 0) {
+                        editorContent
+                        Color.black
+                            .frame(height: 2)
+                        ScrollView {
+                            livePreview
+                        }
+                    }
                 }
             }
-        }
-        .introspectSplitView(customize: { splitView in
-            self.splitView = splitView
-            splitView.dividerStyle = .thin
-        })
-        .toolbar(id: "editorControls") {
-            MarkdownEditorToolbar(document: $conscriptorDocument, showingPreview: showingPreview, textView: textView)
-        }
-        .alert(isPresented: $showingErrorAlert) {
-            Alert(title: Text("Error"), message: Text("Couldn't generate a live preview for the text entered. Please try again."), dismissButton: .cancel())
-        }
-        .onAppear {
-            setupNotifications()
-        }
-        // The following blocks functionally fire only once.
-        .onChange(of: textView) { newValue in
-            if let newValue = newValue {
-                configureTextView(newValue)
-            } else {
-                NSLog("ContentView textView reference invalid", "")
+            .toolbar(id: "editorControls") {
+                MarkdownEditorToolbar(document: $conscriptorDocument, showingPreview: $showingPreview, textView: textView)
             }
-        }
-        .onChange(of: splitView) { newValue in
-            if let newValue = newValue {
-                configureSplitView(newValue)
-            } else {
-                NSLog("ContentView splitView reference invalid", "")
+            .alert(isPresented: $showingErrorAlert) {
+                Alert(title: Text("Error"), message: Text("Couldn't generate a live preview for the text entered. Please try again."), dismissButton: .cancel())
             }
+            .onAppear {
+                setupNotifications()
+            }
+        } else {
+            editorContent
+                .toolbar(id: "editorControls") {
+                    MarkdownEditorToolbar(document: $conscriptorDocument, showingPreview: $showingPreview, textView: textView)
+                }
+                .alert(isPresented: $showingErrorAlert) {
+                    Alert(title: Text("Error"), message: Text("Couldn't generate a live preview for the text entered. Please try again."), dismissButton: .cancel())
+                }
+                .onAppear {
+                    setupNotifications()
+                }
         }
     }
 
@@ -124,18 +106,6 @@ struct MarkdownEditorView: View {
         nc.addObserver(forName: .formatInlineCode, object: nil, queue: .main) { _ in
             MarkdownEditorController.format(&conscriptorDocument, with: .code, in: textView)
         }
-    }
-
-    private func configureTextView(_ textView: NSTextView) {
-        textView.textContainerInset = .init(width: 30, height: 40)
-        textView.usesFontPanel = false
-        if let scrollView = textView.enclosingScrollView {
-            scrollView.autohidesScrollers = true
-        }
-    }
-
-    private func configureSplitView(_ splitView: NSSplitView) {
-        // TODO: find a way to get splitviewcontroller so I can collapse panes in a pretty way with animation
     }
 }
 

--- a/Conscriptor/Views/WebView.swift
+++ b/Conscriptor/Views/WebView.swift
@@ -10,9 +10,11 @@ import WebKit
 
 struct WebView: NSViewRepresentable {
     var html: String
+    var scrollPosition: NSPoint
 
-    init(html: String) {
+    init(html: String, scrollPosition: NSPoint) {
         self.html = html
+        self.scrollPosition = scrollPosition
     }
 
     func makeNSView(context: Context) -> WKWebView {
@@ -42,7 +44,7 @@ struct WebView: NSViewRepresentable {
 
             let webView = WKWebView(frame: .zero,
                                     configuration: configuration)
-            
+            webView.scroll(scrollPosition)
             
             return webView
         }()

--- a/Conscriptor/Views/WebView.swift
+++ b/Conscriptor/Views/WebView.swift
@@ -10,33 +10,18 @@ import WebKit
 
 struct WebView: NSViewRepresentable {
     var html: String
-    var scrollPosition: NSPoint
 
-    init(html: String, scrollPosition: NSPoint) {
+    init(html: String) {
         self.html = html
-        self.scrollPosition = scrollPosition
     }
 
     func makeNSView(context: Context) -> WKWebView {
-        // See https://stackoverflow.com/questions/33123093/insert-css-into-loaded-html-in-uiwebview-wkwebview for details
+        /// See https://stackoverflow.com/questions/33123093/insert-css-into-loaded-html-in-uiwebview-wkwebview for details
         lazy var webView: WKWebView = {
-            guard let path = Bundle.main.path(forResource: context.environment.colorScheme == .light ? "github-light" : "github-dark", ofType: "css"),
-                  let cssString = try? String(contentsOfFile: path, encoding: .utf8).components(separatedBy: .newlines).joined() else {
-                return WKWebView()
-            }
-
-            let source = """
-              var style = document.createElement('style');
-              style.innerHTML = '\(cssString)';
-              document.head.appendChild(style);
-            """
-
-            let userScript = WKUserScript(source: source,
-                                          injectionTime: .atDocumentEnd,
-                                          forMainFrameOnly: true)
-
             let userContentController = WKUserContentController()
-            userContentController.addUserScript(userScript)
+            if let userScript = generateStyleScript(context: context) {
+                userContentController.addUserScript(userScript)
+            }
 
             let configuration = WKWebViewConfiguration()
             configuration.userContentController = userContentController
@@ -44,16 +29,38 @@ struct WebView: NSViewRepresentable {
 
             let webView = WKWebView(frame: .zero,
                                     configuration: configuration)
-            webView.scroll(scrollPosition)
-            
+
             return webView
         }()
         webView.configuration.limitsNavigationsToAppBoundDomains = true
-        
+        /// Thanks https://stackoverflow.com/questions/27211561/transparent-background-wkwebview-nsview/40267954 for this
+        webView.setValue(false, forKey: "drawsBackground")
+
         return webView
     }
 
     func updateNSView(_ nsView: WKWebView, context: Context) {
+        if let userScript = generateStyleScript(context: context) {
+            nsView.configuration.userContentController.addUserScript(userScript)
+        }
         nsView.loadHTMLString(html, baseURL: nil)
+    }
+
+    private func generateStyleScript(context: Context) -> WKUserScript? {
+        guard let path = Bundle.main.path(forResource: context.environment.colorScheme == .light ? "github-light" : "github-dark", ofType: "css"),
+              let cssString = try? String(contentsOfFile: path, encoding: .utf8).components(separatedBy: .newlines).joined() else {
+            print("ERROR: COULD NOT FIND CSS FILES")
+            return nil
+        }
+
+        let source = """
+          var style = document.createElement('style');
+          style.innerHTML = '\(cssString)';
+          document.head.appendChild(style);
+        """
+
+        return WKUserScript(source: source,
+                            injectionTime: .atDocumentEnd,
+                            forMainFrameOnly: true)
     }
 }


### PR DESCRIPTION
After some testing, it looks like the MarkdownUI package isn't a good fit for this project. Reverting back to the previous WKWebView-based live preview.

Also included in this branch:
- Updated .css styles for both light and dark mode to make the background of the live preview effectively transparent. This lets the view blend into the window more, looking less like a webpage.
- Now using the Ink package for Markdown parsing. This supports all the features I need.
- Added (disabled) menu items and commands for inserting images and links.
- SwiftUI's SplitViews are just too buggy to use currently, so the main editor view now uses stacks for its layout. This removes the customizability of the view, however it makes it much more usable and consistently behaves correctly.
- WebView now properly updates its stylesheet when the environment's color scheme changes.